### PR TITLE
Add a CSS for printing

### DIFF
--- a/styles/colorfi-markdown.less
+++ b/styles/colorfi-markdown.less
@@ -435,7 +435,6 @@
     display: block;
     width: 100%;
     overflow: auto;
-    word-break: normal;
     word-break: keep-all;
   }
 
@@ -643,5 +642,12 @@
     z-index: 1;
     position: relative;
     border-color: @link-color-normal;
+  }
+}
+
+.mde-preview.print {
+  table {
+    overflow: hidden;
+    word-break: normal;
   }
 }


### PR DESCRIPTION
As of Inkdrop v3.24.0, it adds `print` class to `mde-preview` when printing.
It would be nice for tables to be rendered properly on paper by adding some CSS with the class.